### PR TITLE
Add sentence translation and additional meanings

### DIFF
--- a/content.css
+++ b/content.css
@@ -780,6 +780,25 @@ select.form-control {
   border-left: 3px solid var(--color-primary);
 }
 
+.context-dict-sentence {
+  font-size: var(--font-size-sm);
+  margin-top: var(--space-8);
+}
+
+.context-dict-others {
+  font-size: var(--font-size-sm);
+  margin-top: var(--space-8);
+}
+
+.context-dict-others ul {
+  margin: var(--space-4) 0 0 16px;
+  padding: 0;
+}
+
+.context-dict-others li {
+  margin-bottom: var(--space-2);
+}
+
 .context-dict-example strong {
   color: var(--color-text);
   font-style: normal;
@@ -859,6 +878,14 @@ select.form-control {
   .context-dict-example {
     padding: var(--space-6);
     margin-top: var(--space-8);
+  }
+
+  .context-dict-sentence {
+    margin-top: var(--space-6);
+  }
+
+  .context-dict-others {
+    margin-top: var(--space-6);
   }
   
   .context-dict-meaning {

--- a/content.js
+++ b/content.js
@@ -141,7 +141,7 @@ function removePopup() {
 // 번역 결과 표시 함수
 function displayTranslation(popup, result) {
   const contentDiv = popup.querySelector('.context-dict-content');
-  
+
   if (result.error) {
     contentDiv.innerHTML = `
       <div class="context-dict-error">
@@ -150,13 +150,18 @@ function displayTranslation(popup, result) {
       </div>
     `;
   } else {
+    const otherList = Array.isArray(result.otherMeanings) && result.otherMeanings.length
+      ? '<ul>' + result.otherMeanings.map(m => `<li>${m.partOfSpeech ? '[' + m.partOfSpeech + '] ' : ''}${m.meaning}</li>`).join('') + '</ul>'
+      : '';
+
     contentDiv.innerHTML = `
       <div class="context-dict-translation">
         <div class="context-dict-meaning">
           <strong>의미:</strong> ${result.meaning}
         </div>
         ${result.partOfSpeech ? `<div class="context-dict-pos"><strong>품사:</strong> ${result.partOfSpeech}</div>` : ''}
-        ${result.example ? `<div class="context-dict-example"><strong>예문:</strong> ${result.example}</div>` : ''}
+        ${result.sentenceTranslation ? `<div class="context-dict-sentence"><strong>문장 번역:</strong> ${result.sentenceTranslation}</div>` : ''}
+        ${otherList ? `<div class="context-dict-others"><strong>다른 뜻:</strong> ${otherList}</div>` : ''}
       </div>
     `;
   }


### PR DESCRIPTION
## Summary
- extend dictionary lookup to return multiple definitions
- update OpenAI prompt to return sentence translation and other meanings
- display sentence translation and list of extra meanings in popup
- style new elements in the popup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68493c43268083218b232e36389601e1